### PR TITLE
Add build system env variables,

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -127,15 +127,13 @@ USER root
 
 # Environment variables for the build system,
 # these need to be only in the "devel" container 
-ENV _R_CHECK_EXECUTABLES_=false \
-	_R_CHECK_EXECUTABLES_EXCLUSIONS_=false \
-	_R_CHECK_LENGTH_1_CONDITION_=package:_R_CHECK_PACKAGE_NAME_,abort,verbose \
-	_R_CHECK_S3_METHODS_NOT_REGISTERED_=true
+## Pull file from github for devel build sys-env variables
+ADD https://raw.githubusercontent.com/Bioconductor/BBS/master/3.11/R_env_vars.sh /root/R_env_vars.sh
 
-RUN echo _R_CHECK_EXECUTABLES_=false >> /etc/environment \
-	&& echo _R_CHECK_EXECUTABLES_EXCLUSIONS_=false >> /etc/environment \
-	&& echo _R_CHECK_LENGTH_1_CONDITION_=package:_R_CHECK_PACKAGE_NAME_,abort,verbose >> /etc/environment \
-	&& echo _R_CHECK_S3_METHODS_NOT_REGISTERED_=true >> /etc/environment
+## Add sys env variables to
+RUN cat /root/R_env_vars.sh | grep -o '^[^#]*' | sed 's/export //g' >>/etc/environment \
+        && cat /root/R_env_vars.sh >> /root/.bashrc \
+	&& rm -rf /root/R_env_vars.sh
 
 # Init command for s6-overlay
 CMD ["/init"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -92,7 +92,7 @@ RUN apt-get update \
 RUN apt-get update \
 	&& apt-get -y --no-install-recommends install python-dev \
 	&& pip install wheel \
-        ## Install sklearn and pandas on python
+	## Install sklearn and pandas on python
 	&& pip install sklearn \
 	pandas \
 	pyyaml \
@@ -102,7 +102,7 @@ RUN apt-get update \
 
 # Install libsbml and xvfb
 RUN cd /tmp \
-        ## libsbml
+	## libsbml
 	&& curl -O https://s3.amazonaws.com/linux-provisioning/libSBML-5.10.2-core-src.tar.gz \
 	&& tar zxf libSBML-5.10.2-core-src.tar.gz \
 	&& cd libsbml-5.10.2 \
@@ -117,13 +117,25 @@ RUN cd /tmp \
 	## Clean libsbml, and tar.gz files
 	&& rm -rf /tmp/libsbml-5.10.2 \
 	&& rm -rf /tmp/libSBML-5.10.2-core-src.tar.gz \
-        ## apt-get clean and remove cache
+	## apt-get clean and remove cache
 	&& apt-get clean \
 	&& rm -rf /var/lib/apt/lists/*
 
 COPY ./deps/xvfb_init /etc/services.d/xvfb/run
 
 USER root
+
+# Environment variables for the build system,
+# these need to be only in the "devel" container 
+ENV _R_CHECK_EXECUTABLES_=false \
+	_R_CHECK_EXECUTABLES_EXCLUSIONS_=false \
+	_R_CHECK_LENGTH_1_CONDITION_=package:_R_CHECK_PACKAGE_NAME_,abort,verbose \
+	_R_CHECK_S3_METHODS_NOT_REGISTERED_=true
+
+RUN echo _R_CHECK_EXECUTABLES_=false >> /etc/environment \
+	&& echo _R_CHECK_EXECUTABLES_EXCLUSIONS_=false >> /etc/environment \
+	&& echo _R_CHECK_LENGTH_1_CONDITION_=package:_R_CHECK_PACKAGE_NAME_,abort,verbose >> /etc/environment \
+	&& echo _R_CHECK_S3_METHODS_NOT_REGISTERED_=true >> /etc/environment
 
 # Init command for s6-overlay
 CMD ["/init"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -126,14 +126,14 @@ COPY ./deps/xvfb_init /etc/services.d/xvfb/run
 USER root
 
 # Environment variables for the build system,
-# these need to be only in the "devel" container 
+# these need to be only in the "devel" container
 ## Pull file from github for devel build sys-env variables
-ADD https://raw.githubusercontent.com/Bioconductor/BBS/master/3.11/R_env_vars.sh /root/R_env_vars.sh
 
 ## Add sys env variables to
-RUN cat /root/R_env_vars.sh | grep -o '^[^#]*' | sed 's/export //g' >>/etc/environment \
-        && cat /root/R_env_vars.sh >> /root/.bashrc \
-	&& rm -rf /root/R_env_vars.sh
+RUN curl -O https://raw.githubusercontent.com/Bioconductor/BBS/master/3.11/R_env_vars.sh \
+	&& cat R_env_vars.sh | grep -o '^[^#]*' | sed 's/export //g' >>/etc/environment \
+	&& cat R_env_vars.sh >> /root/.bashrc \
+	&& rm -rf R_env_vars.sh
 
 # Init command for s6-overlay
 CMD ["/init"]


### PR DESCRIPTION
The build system environment variables are being added to ONLY
bioconductor/bioconductor_full:devel image.

Instead of using ENV, the variables are placed in the /etc/environment
file so that they are available to every user(bioc, rstudio) on the machine.

Test: If you try the command `printenv | grep "_R_CHECK_*"` on any user,
root or bioc or rstudio, you should be able to see the new env
variables.

It seems that adding the build variables to just /etc/environment is only adding the build variables to the users `bioc` and `rstudio`. It is not adding the variables to `root` user. This solution fixes both. 